### PR TITLE
Adding 'setOptions' method to enable modifying the default connection behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ API Reference
 * **Request Property**
   * [`addHeaders`](#addHeaders)
   * [`addParameters`](#addParameters)
+  * [`addOptions`](#addOptions)
   * [`addGlobalHeaders`](#addGlobalHeaders)
   * [`addGlobalParameters`](#addGlobalParameters)
   * [`setBody`](#setBody)
@@ -532,6 +533,26 @@ Adds the given `parameters`*<Array>* to the current request. All parameters are 
     this.api.addParameters(parameters).then(callback);
 ```
 *Note: Don't use it for POST data instead of `setBody` method. The given parameters are placed in a query string, not body*
+
+-------------
+
+
+<a name="addOptions" />
+###addOptions
+
+Adds the given `options`*<Array>* to the current request.
+Options alter the default behaviour of the request.
+
+Example options include:
+* `auth`*<string>*
+* `followRedirect`*<bool>*
+* `strictSSL`*<bool>*
+* `timeout`*<int>*
+* `proxy`*<string>*
+
+```javascript
+    this.api.addOptions(options).then(callback);
+```
 
 -------------
 

--- a/Tester.js
+++ b/Tester.js
@@ -68,6 +68,11 @@ Tester.prototype = {
     next();
   },
 
+  addOptions: function (options, next) {
+    this.req.options = this.merge({}, this.req.options, options);
+    next();
+  },
+
   addHeaders: function (headers, next) {
     if (headers.hashes) {
       headers = this.convertToJson(headers);
@@ -151,12 +156,12 @@ Tester.prototype = {
       this.logger.debug('with body: ' + JSON.stringify(this.req.body));
     }
 
-    var sendObj = {
+    var sendObj = this.merge({
       url: url,
       method: method,
       body: this.req.body,
       headers: headers
-    };
+    }, this.req.options||{} );
 
     this.request(sendObj, function (error, response, body) {
       if (error) throw error;


### PR DESCRIPTION
Can be used to prevent a GET request from automatically following HTTP redirect responses, for example.
